### PR TITLE
Add dashboard screen with firebase statistics

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -64,7 +64,7 @@ const App = () => {
   const [user, setUser] = useState(null);
   const [userId, setUserId] = useState(null);
   const [isAuthReady, setIsAuthReady] = useState(false);
-  const [currentPage, setCurrentPage] = useState('JoinPlans');
+  const [currentPage, setCurrentPage] = useState('Dashboard');
   const [myProfile, setMyProfile] = useState(null); 
   const [userPlans, setUserPlans] = useState([]);
   const [allUsers, setAllUsers] = useState([]);
@@ -593,7 +593,72 @@ const App = () => {
       </div>
     );
   };
-  
+
+  // Dashboard Component
+  const Dashboard = ({ isAdmin, userPlans, allUsers, schemes }) => {
+    if (isAdmin) {
+      const totalUsers = allUsers.length;
+      const activeUsers = allUsers.filter((u) => u.active).length;
+      const totalSchemes = schemes.length;
+      return (
+        <div className="p-4 sm:p-6 lg:p-8">
+          <h2 className="text-3xl font-bold text-indigo-800 mb-6">{t('dashboard')}</h2>
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            <div className="bg-white rounded-xl shadow-lg p-6 border-2 border-gray-200">
+              <h3 className="text-xl font-semibold text-gray-900">{t('total_users')}</h3>
+              <p className="text-3xl font-bold text-indigo-600 mt-2">{totalUsers}</p>
+            </div>
+            <div className="bg-white rounded-xl shadow-lg p-6 border-2 border-gray-200">
+              <h3 className="text-xl font-semibold text-gray-900">{t('active_users')}</h3>
+              <p className="text-3xl font-bold text-indigo-600 mt-2">{activeUsers}</p>
+            </div>
+            <div className="bg-white rounded-xl shadow-lg p-6 border-2 border-gray-200">
+              <h3 className="text-xl font-semibold text-gray-900">{t('total_schemes')}</h3>
+              <p className="text-3xl font-bold text-indigo-600 mt-2">{totalSchemes}</p>
+            </div>
+          </div>
+        </div>
+      );
+    } else {
+      const totalPlans = userPlans.length;
+      const totalPaid = userPlans.reduce((sum, p) => sum + (p.paidAmount || 0), 0);
+      const totalDue = userPlans.reduce(
+        (sum, p) => sum + ((p.totalAmount || 0) - (p.paidAmount || 0)),
+        0
+      );
+      const totalWeight = userPlans.reduce((sum, p) => sum + (p.paidWeight || 0), 0);
+      return (
+        <div className="p-4 sm:p-6 lg:p-8">
+          <h2 className="text-3xl font-bold text-indigo-800 mb-6">{t('dashboard')}</h2>
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            <div className="bg-white rounded-xl shadow-lg p-6 border-2 border-gray-200">
+              <h3 className="text-xl font-semibold text-gray-900">{t('total_plans')}</h3>
+              <p className="text-3xl font-bold text-indigo-600 mt-2">{totalPlans}</p>
+            </div>
+            <div className="bg-white rounded-xl shadow-lg p-6 border-2 border-gray-200">
+              <h3 className="text-xl font-semibold text-gray-900">{t('total_paid')}</h3>
+              <p className="text-3xl font-bold text-indigo-600 mt-2">
+                {formatCurrency(totalPaid)}
+              </p>
+            </div>
+            <div className="bg-white rounded-xl shadow-lg p-6 border-2 border-gray-200">
+              <h3 className="text-xl font-semibold text-gray-900">{t('total_due')}</h3>
+              <p className="text-3xl font-bold text-indigo-600 mt-2">
+                {formatCurrency(totalDue)}
+              </p>
+            </div>
+            <div className="bg-white rounded-xl shadow-lg p-6 border-2 border-gray-200">
+              <h3 className="text-xl font-semibold text-gray-900">{t('total_gold_weight')}</h3>
+              <p className="text-3xl font-bold text-indigo-600 mt-2">
+                {totalWeight.toFixed(3)} g
+              </p>
+            </div>
+          </div>
+        </div>
+      );
+    }
+  };
+
   // MyPlans Screen Component
   const MyPlans = ({ userPlans, onPaymentClick }) => {
     return (
@@ -1169,6 +1234,19 @@ const App = () => {
               <h1 className="text-2xl font-bold text-indigo-800">DigiGold</h1>
             </div>
             <ul className="space-y-2 flex-grow">
+              <li>
+                <button
+                  onClick={() => setCurrentPage("Dashboard")}
+                  className={`w-full flex items-center p-3 rounded-xl transition-colors hover:bg-indigo-100 hover:text-indigo-800 ${
+                    currentPage === "Dashboard"
+                      ? "bg-indigo-50 text-indigo-800 font-semibold"
+                      : "text-gray-600"
+                  }`}
+                >
+                  <HomeIcon className="mr-3" />
+                  {t("dashboard")}
+                </button>
+              </li>
               {!isAdmin && (
                 <li>
                   <button
@@ -1238,8 +1316,17 @@ const App = () => {
             </div>
           </div>
           <div className="md:hidden flex justify-around p-2 bg-white border-t-2 border-gray-200">
-           
-           {
+            <button
+              onClick={() => setCurrentPage("Dashboard")}
+              className={`flex flex-col items-center p-2 rounded-xl transition-colors ${
+                currentPage === "Dashboard" ? "text-indigo-800" : "text-gray-500"
+              }`}
+            >
+              <HomeIcon />
+              <span className="text-xs">{t("dashboard_nav")}</span>
+            </button>
+
+            {
             !isAdmin && (
               <button
               onClick={() => setCurrentPage("MyPlans")}
@@ -1251,7 +1338,7 @@ const App = () => {
               <span className="text-xs">{t("plans_nav")}</span>
             </button>
             )
-           } 
+           }
             <button
               onClick={() => setCurrentPage("JoinPlans")}
               className={`flex flex-col items-center p-2 rounded-xl transition-colors ${
@@ -1290,6 +1377,14 @@ const App = () => {
           </div>
         </nav>
         <div className="container mx-auto">
+          {currentPage === "Dashboard" && (
+            <Dashboard
+              isAdmin={isAdmin}
+              userPlans={userPlans}
+              allUsers={allUsers}
+              schemes={schemes}
+            />
+          )}
           {currentPage === "MyPlans" && (
             <MyPlans
               userPlans={userPlans}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -102,5 +102,14 @@
   "users_nav": "Users",
   "language": "Language",
   "english": "English",
-  "tamil": "Tamil"
+  "tamil": "Tamil",
+  "dashboard": "Dashboard",
+  "total_users": "Total Users",
+  "active_users": "Active Users",
+  "total_schemes": "Total Schemes",
+  "total_plans": "Total Plans",
+  "total_paid": "Total Paid",
+  "total_due": "Total Due",
+  "total_gold_weight": "Total Gold Weight",
+  "dashboard_nav": "Dashboard"
 }

--- a/src/locales/ta.json
+++ b/src/locales/ta.json
@@ -102,5 +102,14 @@
   "users_nav": "பயனர்கள்",
   "language": "மொழி",
   "english": "ஆங்கிலம்",
-  "tamil": "தமிழ்"
+  "tamil": "தமிழ்",
+  "dashboard": "டாஷ்போர்டு",
+  "total_users": "மொத்த பயனர்கள்",
+  "active_users": "செயலில் உள்ள பயனர்கள்",
+  "total_schemes": "மொத்த திட்டங்கள்",
+  "total_plans": "மொத்த திட்டங்கள்",
+  "total_paid": "மொத்தம் செலுத்தப்பட்டது",
+  "total_due": "மொத்த பாக்கி",
+  "total_gold_weight": "மொத்த தங்க எடை",
+  "dashboard_nav": "டாஷ்போர்டு"
 }


### PR DESCRIPTION
## Summary
- add dashboard screen that aggregates user or admin statistics
- hook dashboard into navigation and show it by default
- localize dashboard labels in English and Tamil

## Testing
- `npm install --legacy-peer-deps`
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68960e37e964832b9f45ef6bcf63c5a7